### PR TITLE
Strip nulls

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ const defaultOptions = {
 	caseSensitive: true, // Ignores case when initializing object from model
 	strict: false, // Throws an error if key is not in schema
 	stripUndefined: true, // Strip undefined values passed in
+	stripNull: false, // Do not strip null values passed in
 };
 ```
 
@@ -562,6 +563,46 @@ const schema = {
 const model = createModel(schema);
 const data = model({ foo: undefined });
 // => { foo: undefined }
+```
+
+## stripNull
+
+This will remove any null values from the initial object passed in.
+
+```js
+const { createModel } = require('nativemodels');
+const { string } = require('nativemodels/datatypes');
+
+const options = {
+	stripNull: true,
+};
+
+const schema = {
+	foo: string(),
+};
+
+const model = createModel(schema);
+const data = model({ foo: null });
+// => {}
+```
+
+Versus
+
+```js
+const { createModel } = require('nativemodels');
+const { string } = require('nativemodels/datatypes');
+
+const options = {
+	stripNull: false,
+};
+
+const schema = {
+	foo: string(),
+};
+
+const model = createModel(schema);
+const data = model({ foo: null });
+// => Error: NativeModels - Failed valid check.  Key: foo | Value: null
 ```
 
 ## createModel context

--- a/src/lib/defaultOptions.js
+++ b/src/lib/defaultOptions.js
@@ -9,6 +9,8 @@ const defaultOptions = {
 	strict: false,
 	// Strip undefined values passed in
 	stripUndefined: true,
+	// Strip null values passed in
+	stripNull: false,
 };
 
 module.exports = defaultOptions;

--- a/src/lib/parseValue.js
+++ b/src/lib/parseValue.js
@@ -18,7 +18,9 @@ const runChecks = (type, key, value) => {
 };
 
 const parseValue = (type, key, value, options) => {
-	if ((type.allowNull || (options && options.allowNulls)) && isNull(value)) {
+	if (options.stripNulls && isNull(value)) {
+		return undefined;
+	} else if ((type.allowNull || (options && options.allowNulls)) && isNull(value)) {
 		return null;
 	} else if (invalidTypeCheck(type, key, value)) {
 		return value;

--- a/tests/stripNulls.test.js
+++ b/tests/stripNulls.test.js
@@ -1,0 +1,19 @@
+const {
+	createModel,
+	datatypes: { string },
+} = require('./../src');
+
+test('stripNulls - default test', async () => {
+	const model = createModel({ foo: string() });
+
+    await expect(() => {
+		model({ foo: null });
+	}).toThrow();
+});
+
+test('stripNulls - normal test', async () => {
+	const model = createModel({ foo: string() }, { stripNulls: true });
+	const result = model({ foo: null });
+
+	await expect(result).toEqual({});
+});


### PR DESCRIPTION
Allows for another option `stripNull` that will strip null values from a record instead of throwing during the validity check. This is especially useful when getting data from a database where null values in the database commonly translate to null values in js. This can be an issue because although there is an `allowNulls` option transformers are not run on null values, so null values will remain in the object and another layer of checks has to be coded to clean out the nulls.